### PR TITLE
Fix htttps:// typo in contribution template

### DIFF
--- a/HowToContribute.md
+++ b/HowToContribute.md
@@ -15,8 +15,8 @@
 ```
 | Product | CVE(s) | Ransomware Group(s) | Source(s) |
 |---|---|---|---|
-| product_name | cve_number | group_name | [xyz.com](htttps://LINK_GOES_HERE) |
-| product_name | cve_number & cve_number | group_name, group_name | [abc.com](htttps://xxx) / [xyz.com](htttps://xxx) |
+| product_name | cve_number | group_name | [xyz.com](https://LINK_GOES_HERE) |
+| product_name | cve_number & cve_number | group_name, group_name | [abc.com](https://xxx) / [xyz.com](https://xxx) |
 ```
 
 ### Providing Evidence


### PR DESCRIPTION
Lines 18-19 of `HowToContribute.md` show the example/template format for contributing entries. The protocol prefix is `htttps://` (extra t) in 3 places (`LINK_GOES_HERE`, two `xxx` placeholders). New contributors copying from this template would inherit the typo.

This PR fixes all 3 to `https://`. The placeholder values (`LINK_GOES_HERE`, `xxx`) are intentionally left intact.